### PR TITLE
update installation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation (Debian)
    Es sollte keine Software vorausgewählt sein.)
 * Als Benutzer `root`:
     * Git installieren:  
-        `apt-get -y --no-install-recommends install git`
+        `apt-get -y --no-install-recommends install git ca-certificates`
     * Repository klonen:  
         `git clone https://github.com/michz/shinage-player-debian.git`
     * Ins neue Verzeichnis wechseln:  


### PR DESCRIPTION
depending on your install package ca-certificates is needed in order to clone https-git